### PR TITLE
Add real-time microphone transcription and coaching suggestions

### DIFF
--- a/src/contexts/InterviewContext.tsx
+++ b/src/contexts/InterviewContext.tsx
@@ -1,5 +1,12 @@
 import React, { createContext, useState, useContext, ReactNode } from 'react';
 
+export interface Suggestion {
+  id: string;
+  title: string;
+  content: string;
+  confidence?: number;
+}
+
 interface InterviewContextType {
   currentText: string;
   setCurrentText: React.Dispatch<React.SetStateAction<string>>;
@@ -9,6 +16,8 @@ interface InterviewContextType {
   setDisplayedAiResult: React.Dispatch<React.SetStateAction<string>>;
   lastProcessedIndex: number;
   setLastProcessedIndex: React.Dispatch<React.SetStateAction<number>>;
+  suggestions: Suggestion[];
+  setSuggestions: React.Dispatch<React.SetStateAction<Suggestion[]>>;
 }
 
 const InterviewContext = createContext<InterviewContextType | undefined>(undefined);
@@ -18,6 +27,7 @@ export const InterviewProvider: React.FC<{ children: ReactNode }> = ({ children 
   const [aiResult, setAiResult] = useState("");
   const [displayedAiResult, setDisplayedAiResult] = useState("");
   const [lastProcessedIndex, setLastProcessedIndex] = useState(0);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
 
   return (
     <InterviewContext.Provider
@@ -30,6 +40,8 @@ export const InterviewProvider: React.FC<{ children: ReactNode }> = ({ children 
         setDisplayedAiResult,
         lastProcessedIndex,
         setLastProcessedIndex,
+        suggestions,
+        setSuggestions,
       }}
     >
       {children}

--- a/src/index.ts
+++ b/src/index.ts
@@ -418,7 +418,7 @@ ipcMain.handle("start-deepgram", async (event, config) => {
     const deepgram = createClient(config.deepgram_key);
     deepgramConnection = deepgram.listen.live({
       punctuate: true,
-      interim_results: false,
+      interim_results: true,
       model: "general",
       language: config.primaryLanguage || "en",
       encoding: "linear16",
@@ -439,16 +439,17 @@ ipcMain.handle("start-deepgram", async (event, config) => {
       (data: any) => {
         if (
           data &&
-          data.is_final &&
           data.channel &&
           data.channel.alternatives &&
           data.channel.alternatives[0]
         ) {
           const transcript = data.channel.alternatives[0].transcript;
+          const confidence = data.channel.alternatives[0].confidence;
           if (transcript) {
             event.sender.send("deepgram-transcript", {
               transcript,
-              is_final: true,
+              is_final: Boolean(data.is_final),
+              confidence,
             });
           }
         }

--- a/src/pages/InterviewPage.tsx
+++ b/src/pages/InterviewPage.tsx
@@ -11,8 +11,8 @@ import Timer from "../components/Timer";
 import { useKnowledgeBase } from "../contexts/KnowledgeBaseContext";
 import ErrorDisplay from "../components/ErrorDisplay";
 import { useError } from "../contexts/ErrorContext";
-import { useInterview } from "../contexts/InterviewContext";
-import ReactMarkdown from 'react-markdown';
+import { useInterview, Suggestion } from "../contexts/InterviewContext";
+import ReactMarkdown from "react-markdown";
 
 const InterviewPage: React.FC = () => {
   const { knowledgeBase, conversations, addConversation, clearConversations } = useKnowledgeBase();
@@ -20,12 +20,12 @@ const InterviewPage: React.FC = () => {
   const {
     currentText,
     setCurrentText,
-    aiResult,
-    setAiResult,
     displayedAiResult,
     setDisplayedAiResult,
     lastProcessedIndex,
-    setLastProcessedIndex
+    setLastProcessedIndex,
+    suggestions,
+    setSuggestions,
   } = useInterview();
   const [isRecording, setIsRecording] = useState(false);
   const [isConfigured, setIsConfigured] = useState(false);
@@ -34,8 +34,14 @@ const InterviewPage: React.FC = () => {
   const [userMedia, setUserMedia] = useState<MediaStream | null>(null);
   const [audioContext, setAudioContext] = useState<AudioContext | null>(null);
   const [processor, setProcessor] = useState<ScriptProcessorNode | null>(null);
-  const [autoSubmitTimer, setAutoSubmitTimer] = useState<NodeJS.Timeout | null>(null);
+  const [partialTranscript, setPartialTranscript] = useState("");
+  const [isGeneratingSuggestions, setIsGeneratingSuggestions] = useState(false);
   const aiResponseRef = useRef<HTMLDivElement>(null);
+  const autoSubmitTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const suggestionTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingSuggestionRef = useRef<string>("");
+  const lastFinalTranscriptRef = useRef<string>("");
+  const transcriptRef = useRef<string>("");
 
   const markdownStyles = `
     .markdown-body {
@@ -68,6 +74,110 @@ const InterviewPage: React.FC = () => {
       border-radius: 3px;
     }
   `;
+
+  const createSuggestionId = () =>
+    window.crypto?.randomUUID?.() ?? `suggestion-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+
+  const normaliseSuggestionArray = (input: any[]): Suggestion[] => {
+    const results: Suggestion[] = [];
+
+    input.forEach((item, index) => {
+      if (!item) {
+        return;
+      }
+
+      if (typeof item === "string") {
+        results.push({
+          id: createSuggestionId(),
+          title: `Suggestion ${index + 1}`,
+          content: item.trim(),
+        });
+        return;
+      }
+
+      if (typeof item === "object") {
+        const title =
+          (typeof item.title === "string" && item.title.trim()) ||
+          (typeof item.heading === "string" && item.heading.trim()) ||
+          (typeof item.topic === "string" && item.topic.trim()) ||
+          `Suggestion ${index + 1}`;
+        const content =
+          (typeof item.content === "string" && item.content.trim()) ||
+          (typeof item.suggestion === "string" && item.suggestion.trim()) ||
+          (typeof item.prompt === "string" && item.prompt.trim()) ||
+          (typeof item.text === "string" && item.text.trim()) ||
+          "";
+        const confidence =
+          typeof item.confidence === "number"
+            ? Math.round(Math.max(0, Math.min(1, item.confidence)) * 100) / 100
+            : undefined;
+
+        if (!content) {
+          return;
+        }
+
+        results.push({
+          id: createSuggestionId(),
+          title,
+          content,
+          confidence,
+        });
+      }
+    });
+
+    return results;
+  };
+
+  const parseSuggestions = (raw: string): Suggestion[] => {
+    const cleaned = raw.trim();
+    if (!cleaned) {
+      return [];
+    }
+
+    const jsonMatch = cleaned.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[0]);
+        if (Array.isArray(parsed)) {
+          const result = normaliseSuggestionArray(parsed);
+          if (result.length) {
+            return result;
+          }
+        } else if (parsed && typeof parsed === "object") {
+          const arrayCandidate = parsed.suggestions || parsed.prompts || parsed.items;
+          if (Array.isArray(arrayCandidate)) {
+            const result = normaliseSuggestionArray(arrayCandidate);
+            if (result.length) {
+              return result;
+            }
+          }
+        }
+      } catch (error) {
+        // Fallback to non-JSON parsing
+      }
+    }
+
+    const lines = cleaned
+      .split(/\n+/)
+      .map((line) => line.replace(/^\s*(?:[-*]|\d+[.)])\s*/, "").trim())
+      .filter(Boolean);
+
+    return lines.slice(0, 3).map((line, index) => {
+      const hasDivider = line.includes(":");
+      const [rawTitle, ...rest] = hasDivider ? line.split(":") : [line];
+      const title = hasDivider ? rawTitle.trim() : `Suggestion ${index + 1}`;
+      const content = hasDivider ? rest.join(":").trim() : line;
+      return {
+        id: createSuggestionId(),
+        title: title || `Suggestion ${index + 1}`,
+        content,
+      };
+    });
+  };
+
+  useEffect(() => {
+    transcriptRef.current = currentText;
+  }, [currentText]);
 
   useEffect(() => {
     loadConfig();
@@ -114,41 +224,156 @@ const InterviewPage: React.FC = () => {
     handleAskGPT(newContent);
   }, [handleAskGPT]);
 
+  const generateSuggestions = useCallback(
+    async (latestSegment: string, transcriptSnapshot: string) => {
+      const trimmedSegment = latestSegment.trim();
+      if (!trimmedSegment) {
+        return;
+      }
+
+      setIsGeneratingSuggestions(true);
+      try {
+        const config = await window.electronAPI.getConfig();
+        const knowledgeContext = knowledgeBase.slice(-5).join("\n");
+        const condensedTranscript = transcriptSnapshot
+          .split(/\n/)
+          .filter(Boolean)
+          .slice(-12)
+          .join("\n");
+
+        const systemPrompt =
+          "You are an AI interview coach that listens to a live client interview and drafts succinct, high-impact prompts the candidate can use to respond effectively." +
+          " Suggestions must be grounded in the client's latest question, highlight differentiators from the knowledge base when relevant, and remain under 220 characters.";
+
+        const instructionPrompt =
+          "Produce 2-3 actionable suggestions that help the candidate respond to the interviewer next." +
+          " Return a JSON array where each item has `title`, `suggestion`, and optional `confidence` between 0 and 1." +
+          " Focus on the immediate context without repeating the transcript verbatim.";
+
+        const messages = [
+          { role: "system", content: systemPrompt },
+          knowledgeContext
+            ? {
+                role: "user" as const,
+                content: `Reference knowledge base entries:\n${knowledgeContext}`,
+              }
+            : null,
+          condensedTranscript
+            ? {
+                role: "user" as const,
+                content: `Transcript so far:\n${condensedTranscript}`,
+              }
+            : null,
+          {
+            role: "user" as const,
+            content: `Latest interviewer input to analyse:\n${trimmedSegment}`,
+          },
+          {
+            role: "user" as const,
+            content: instructionPrompt,
+          },
+        ].filter(Boolean);
+
+        const response = await window.electronAPI.callOpenAI({
+          config,
+          messages,
+        });
+
+        if ("error" in response) {
+          throw new Error(response.error);
+        }
+
+        const parsedSuggestions = parseSuggestions(response.content);
+        if (parsedSuggestions.length) {
+          setSuggestions(parsedSuggestions.slice(0, 3));
+        }
+      } catch (err) {
+        console.error("Failed to generate suggestions", err);
+        setError("Unable to generate AI suggestions at the moment. Please try again.");
+      } finally {
+        setIsGeneratingSuggestions(false);
+      }
+    },
+    [knowledgeBase, setError, setSuggestions]
+  );
+
+  const queueSuggestion = useCallback(
+    (latestSegment: string, transcriptSnapshot: string) => {
+      pendingSuggestionRef.current = pendingSuggestionRef.current
+        ? `${pendingSuggestionRef.current}\n${latestSegment}`
+        : latestSegment;
+
+      if (suggestionTimerRef.current) {
+        clearTimeout(suggestionTimerRef.current);
+      }
+
+      suggestionTimerRef.current = setTimeout(() => {
+        const payload = pendingSuggestionRef.current.trim();
+        pendingSuggestionRef.current = "";
+        if (payload) {
+          generateSuggestions(payload, transcriptSnapshot);
+        }
+      }, 800);
+    },
+    [generateSuggestions]
+  );
+
   useEffect(() => {
     let lastTranscriptTime = Date.now();
     let checkTimer: NodeJS.Timeout | null = null;
 
-    const handleDeepgramTranscript = (_event: any, data: any) => {
-      if (data.transcript && data.is_final) {
+    const scheduleAutoSubmit = (updatedText: string) => {
+      if (!isAutoGPTEnabled) {
+        return;
+      }
+
+      if (autoSubmitTimerRef.current) {
+        clearTimeout(autoSubmitTimerRef.current);
+      }
+
+      autoSubmitTimerRef.current = setTimeout(() => {
+        const newContent = updatedText.slice(lastProcessedIndex);
+        if (newContent.trim()) {
+          handleAskGPTStable(newContent);
+        }
+      }, 1800);
+    };
+
+    const handleDeepgramTranscript = (
+      _event: any,
+      data: { transcript?: string; is_final?: boolean }
+    ) => {
+      const transcript = data?.transcript?.trim();
+      if (!transcript) {
+        return;
+      }
+
+      lastTranscriptTime = Date.now();
+
+      if (data.is_final) {
+        setPartialTranscript("");
+
         setCurrentText((prev: string) => {
-          const newTranscript = data.transcript.trim();
-          if (!prev.endsWith(newTranscript)) {
-            lastTranscriptTime = Date.now();
-            const updatedText = prev + (prev ? '\n' : '') + newTranscript;
-            
-            if (isAutoGPTEnabled) {
-              if (autoSubmitTimer) {
-                clearTimeout(autoSubmitTimer);
-              }
-              const newTimer = setTimeout(() => {
-                const newContent = updatedText.slice(lastProcessedIndex);
-                if (newContent.trim()) {
-                  handleAskGPTStable(newContent);
-                }
-              }, 2000);
-              setAutoSubmitTimer(newTimer);
-            }
-            
-            return updatedText;
+          if (lastFinalTranscriptRef.current === transcript && prev.endsWith(transcript)) {
+            return prev;
           }
-          return prev;
+
+          const updatedText = prev ? `${prev}\n${transcript}` : transcript;
+          lastFinalTranscriptRef.current = transcript;
+          transcriptRef.current = updatedText;
+
+          scheduleAutoSubmit(updatedText);
+          queueSuggestion(transcript, updatedText);
+          return updatedText;
         });
+      } else {
+        setPartialTranscript(transcript);
       }
     };
 
     const checkAndSubmit = () => {
       if (isAutoGPTEnabled && Date.now() - lastTranscriptTime >= 2000) {
-        const newContent = currentText.slice(lastProcessedIndex);
+        const newContent = transcriptRef.current.slice(lastProcessedIndex);
         if (newContent.trim()) {
           handleAskGPTStable(newContent);
         }
@@ -156,16 +381,22 @@ const InterviewPage: React.FC = () => {
       checkTimer = setTimeout(checkAndSubmit, 1000);
     };
 
-    window.electronAPI.ipcRenderer.on('deepgram-transcript', handleDeepgramTranscript);
+    window.electronAPI.ipcRenderer.on(
+      "deepgram-transcript",
+      handleDeepgramTranscript
+    );
     checkTimer = setTimeout(checkAndSubmit, 1000);
 
     return () => {
-      window.electronAPI.ipcRenderer.removeListener('deepgram-transcript', handleDeepgramTranscript);
+      window.electronAPI.ipcRenderer.removeListener(
+        "deepgram-transcript",
+        handleDeepgramTranscript
+      );
       if (checkTimer) {
         clearTimeout(checkTimer);
       }
     };
-  }, [isAutoGPTEnabled, lastProcessedIndex, currentText, handleAskGPTStable, setCurrentText, setLastProcessedIndex]);
+  }, [handleAskGPTStable, isAutoGPTEnabled, lastProcessedIndex, queueSuggestion, setCurrentText]);
 
   const loadConfig = async () => {
     try {
@@ -181,27 +412,50 @@ const InterviewPage: React.FC = () => {
   };
 
   const startRecording = async () => {
+    let stream: MediaStream | null = null;
     try {
-      const stream = await navigator.mediaDevices.getDisplayMedia({
-        video: false,
+      stream = await navigator.mediaDevices.getUserMedia({
         audio: {
+          channelCount: 1,
           echoCancellation: true,
           noiseSuppression: true,
           sampleRate: 16000,
         },
+        video: false,
       });
-      setUserMedia(stream);
+
+      if (!stream.getAudioTracks().length) {
+        throw new Error("No microphone input detected");
+      }
+
+      if (autoSubmitTimerRef.current) {
+        clearTimeout(autoSubmitTimerRef.current);
+        autoSubmitTimerRef.current = null;
+      }
+      if (suggestionTimerRef.current) {
+        clearTimeout(suggestionTimerRef.current);
+        suggestionTimerRef.current = null;
+      }
+
+      pendingSuggestionRef.current = "";
+      lastFinalTranscriptRef.current = "";
+      transcriptRef.current = "";
+
+      setPartialTranscript("");
+      setSuggestions([]);
 
       const config = await window.electronAPI.getConfig();
       const result = await window.electronAPI.ipcRenderer.invoke('start-deepgram', {
         deepgram_key: config.deepgram_api_key
       });
       if (!result.success) {
+        stream.getTracks().forEach((track) => track.stop());
         throw new Error(result.error);
       }
 
       const context = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: 16000 });
       setAudioContext(context);
+      await context.resume();
       const source = context.createMediaStreamSource(stream);
       const processor = context.createScriptProcessor(4096, 1, 1);
       setProcessor(processor);
@@ -218,8 +472,17 @@ const InterviewPage: React.FC = () => {
         window.electronAPI.ipcRenderer.invoke('send-audio-to-deepgram', audioData.buffer);
       };
 
+      setUserMedia(stream);
       setIsRecording(true);
     } catch (err: any) {
+      if (stream) {
+        stream.getTracks().forEach((track) => track.stop());
+      }
+      setIsRecording(false);
+      setUserMedia(null);
+      setAudioContext(null);
+      setProcessor(null);
+      console.error("Failed to start microphone capture", err);
       setError("Failed to start recording. Please check permissions or try again.");
     }
   };
@@ -234,11 +497,22 @@ const InterviewPage: React.FC = () => {
     if (processor) {
       processor.disconnect();
     }
+    if (autoSubmitTimerRef.current) {
+      clearTimeout(autoSubmitTimerRef.current);
+      autoSubmitTimerRef.current = null;
+    }
+    if (suggestionTimerRef.current) {
+      clearTimeout(suggestionTimerRef.current);
+      suggestionTimerRef.current = null;
+    }
+    pendingSuggestionRef.current = "";
+    lastFinalTranscriptRef.current = "";
     window.electronAPI.ipcRenderer.invoke('stop-deepgram');
     setIsRecording(false);
     setUserMedia(null);
     setAudioContext(null);
     setProcessor(null);
+    setPartialTranscript("");
   };
 
   useEffect(() => {
@@ -287,14 +561,20 @@ const InterviewPage: React.FC = () => {
           <span>Auto GPT</span>
         </label>
       </div>
-      <div className="flex flex-1 space-x-2 overflow-hidden">
-        <div className="flex-1 flex flex-col bg-base-200 p-2 rounded-lg">
+      <div className="flex-1 grid grid-cols-1 gap-2 overflow-hidden md:grid-cols-2 xl:grid-cols-3">
+        <div className="flex flex-col bg-base-200 p-2 rounded-lg">
           <textarea
             value={currentText}
             onChange={(e) => setCurrentText(e.target.value)}
             className="textarea textarea-bordered flex-1 mb-1 bg-base-100 min-h-[80px] whitespace-pre-wrap"
             placeholder="Transcribed text will appear here..."
           />
+          {partialTranscript && (
+            <div className="bg-base-100 border border-dashed border-base-300 text-sm text-base-content/70 rounded-md p-2 mb-2">
+              <span className="font-semibold text-base-content">Listening…</span>
+              <p className="mt-1 whitespace-pre-wrap">{partialTranscript}</p>
+            </div>
+          )}
           <button
             onClick={() => setCurrentText("")}
             className="btn btn-ghost mt-1"
@@ -302,8 +582,52 @@ const InterviewPage: React.FC = () => {
             Clear Content
           </button>
         </div>
-        <div className="flex-1 flex flex-col bg-base-200 p-2 rounded-lg">
-          <div 
+        <div className="flex flex-col bg-base-200 p-2 rounded-lg overflow-hidden">
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="text-lg font-bold">AI Suggestions</h2>
+            <button
+              onClick={() => setSuggestions([])}
+              className="btn btn-ghost btn-xs"
+              disabled={!suggestions.length && !isGeneratingSuggestions}
+            >
+              Clear
+            </button>
+          </div>
+          <div className="flex-1 overflow-auto space-y-2 pr-1">
+            {isGeneratingSuggestions && (
+              <div className="animate-pulse text-sm text-base-content/70">
+                Generating suggestions in real time…
+              </div>
+            )}
+            {suggestions.map((suggestion) => (
+              <div
+                key={suggestion.id}
+                className="bg-base-100 border border-base-300 rounded-md p-2 shadow-sm"
+              >
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold text-sm text-base-content">
+                    {suggestion.title}
+                  </h3>
+                  {typeof suggestion.confidence === "number" && (
+                    <span className="text-xs text-base-content/60">
+                      Confidence {(suggestion.confidence * 100).toFixed(0)}%
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-sm whitespace-pre-wrap text-base-content/80">
+                  {suggestion.content}
+                </p>
+              </div>
+            ))}
+            {!isGeneratingSuggestions && !suggestions.length && (
+              <p className="text-sm text-base-content/60">
+                Contextual prompts will appear here as soon as the interviewer speaks.
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col bg-base-200 p-2 rounded-lg">
+          <div
             ref={aiResponseRef}
             className="flex-1 overflow-auto bg-base-100 p-2 rounded mb-1 min-h-[80px]"
           >


### PR DESCRIPTION
## Summary
- capture microphone audio immediately when recording starts and stream partial/final results from Deepgram
- enrich interview context with AI-generated coaching suggestions and shared state for rendering them in the UI
- update the interview page to display live transcript progress, suggestion cards, and improved cleanup logic for timers

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e1ca1bd2a8832eb12393bd72e0ff35