### PR TITLE
Enhance real-time interview assistance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -418,7 +418,7 @@ ipcMain.handle("start-deepgram", async (event, config) => {
     const deepgram = createClient(config.deepgram_key);
     deepgramConnection = deepgram.listen.live({
       punctuate: true,
-      interim_results: false,
+      interim_results: true,
       model: "general",
       language: config.primaryLanguage || "en",
       encoding: "linear16",
@@ -439,16 +439,17 @@ ipcMain.handle("start-deepgram", async (event, config) => {
       (data: any) => {
         if (
           data &&
-          data.is_final &&
           data.channel &&
           data.channel.alternatives &&
           data.channel.alternatives[0]
         ) {
-          const transcript = data.channel.alternatives[0].transcript;
+          const alternative = data.channel.alternatives[0];
+          const transcript = (alternative.transcript || "").trim();
           if (transcript) {
             event.sender.send("deepgram-transcript", {
               transcript,
-              is_final: true,
+              is_final: Boolean(data.is_final),
+              confidence: alternative.confidence,
             });
           }
         }


### PR DESCRIPTION
## Summary
- request interim transcripts from Deepgram and forward both partial and final results to the renderer
- update the interview page to auto-capture microphone audio, surface live transcript text, and manage cleanup when recording stops
- refresh the suggestion panel to stream contextual prompts in real time with improved auto-submit timing and manual controls

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1ca1bd2a8832eb12393bd72e0ff35