### PR TITLE
Segment AI responses into discrete cards

### DIFF
--- a/src/contexts/InterviewContext.tsx
+++ b/src/contexts/InterviewContext.tsx
@@ -1,12 +1,20 @@
 import React, { createContext, useState, useContext, ReactNode } from 'react';
 
+export interface ResponseSegment {
+  id: string;
+  text: string;
+  metadata?: {
+    timestamp: number;
+  };
+}
+
 interface InterviewContextType {
   currentText: string;
   setCurrentText: React.Dispatch<React.SetStateAction<string>>;
   aiResult: string;
   setAiResult: React.Dispatch<React.SetStateAction<string>>;
-  displayedAiResult: string;
-  setDisplayedAiResult: React.Dispatch<React.SetStateAction<string>>;
+  displayedAiResult: ResponseSegment[];
+  setDisplayedAiResult: React.Dispatch<React.SetStateAction<ResponseSegment[]>>;
   lastProcessedIndex: number;
   setLastProcessedIndex: React.Dispatch<React.SetStateAction<number>>;
 }
@@ -16,7 +24,7 @@ const InterviewContext = createContext<InterviewContextType | undefined>(undefin
 export const InterviewProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [currentText, setCurrentText] = useState("");
   const [aiResult, setAiResult] = useState("");
-  const [displayedAiResult, setDisplayedAiResult] = useState("");
+  const [displayedAiResult, setDisplayedAiResult] = useState<ResponseSegment[]>([]);
   const [lastProcessedIndex, setLastProcessedIndex] = useState(0);
 
   return (


### PR DESCRIPTION
## Summary
- refactor the interview context to store assistant replies as structured segments with metadata
- adjust the interview page to append new segments, render them as compact cards, and add copy/collapse controls per segment
- tighten markdown spacing for clearer stacked replies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23e54bcfc832eb3f520a3f55eb7c4