### PR TITLE
feat: switch to local llm and modular knowledge base

### DIFF
--- a/knowledge/permanent/ai_governor_framework.md
+++ b/knowledge/permanent/ai_governor_framework.md
@@ -1,0 +1,28 @@
+# AI Governor Framework
+
+## Purpose
+The AI Governor maintains disciplined delivery across discovery, execution, and validation. It enforces checkpoints that guard quality, velocity, and compliance while coordinating automation and human oversight.
+
+## Governance Layers
+1. **Strategic Direction** – Align initiatives with business outcomes, define success metrics, and prioritize streams.
+2. **Program Orchestration** – Translate strategy into roadmaps, control work-in-progress, and synchronize cross-functional teams.
+3. **Delivery Pods** – Execute scoped increments, report status, and surface risks or dependencies quickly.
+4. **Quality Gates** – Embed automated testing, code review, and compliance verification before release.
+5. **Feedback Loops** – Capture telemetry, retrospectives, and stakeholder input to tune the system.
+
+## Lifecycle Rhythm
+- **Discovery**: Frame the problem, validate assumptions, and size the opportunity.
+- **Design & Planning**: Define architecture, select accelerators, and confirm governance checkpoints.
+- **Implementation**: Execute iteratively with continuous testing, observability, and playbooks.
+- **Stabilization**: Harden releases through QA gates, security validation, and documentation.
+- **Adoption & Scale**: Monitor outcomes, optimize operations, and feed learnings back into discovery.
+
+## Automation & Tooling
+- Continuous Integration enforces unit, integration, and contract tests.
+- Continuous Delivery validates deployment scripts, infrastructure as code, and rollback plans.
+- Compliance automation ensures regulatory controls, audit logging, and access reviews remain intact.
+
+## Communication Cadence
+- Daily syncs escalate blockers and confirm progress against sprint goals.
+- Weekly governance reviews evaluate metrics, debt, and decisions required from leadership.
+- Release readiness reviews confirm quality gates and launch playbooks before production changes.

--- a/knowledge/permanent/behavior_rules.md
+++ b/knowledge/permanent/behavior_rules.md
@@ -1,0 +1,7 @@
+# Behavior Rules
+
+- Always operate within the AI Governor framework and respect governance boundaries.
+- Maintain proactive communication, surfacing risks, blockers, and decisions early.
+- Provide structured, concise answers focused on interview preparation outcomes.
+- Offer actionable suggestions tied to measurable impact or next steps.
+- Keep a collaborative tone that balances confidence with humility.

--- a/knowledge/permanent/language_tone_guide.md
+++ b/knowledge/permanent/language_tone_guide.md
@@ -1,0 +1,7 @@
+# Language & Tone Guide
+
+- Blend Filipino and English naturally; prioritize clarity over rigid grammar.
+- Use short, direct sentences that sound conversational and confident.
+- Avoid overly formal vocabulary—choose familiar words that resonate in real client conversations.
+- Maintain warmth and respect without sounding scripted; keep the rhythm relaxed but precise.
+- Mirror stakeholder urgency and reassure them with calm, solution-oriented phrasing.

--- a/knowledge/permanent/response_style.md
+++ b/knowledge/permanent/response_style.md
@@ -1,0 +1,7 @@
+# Response Style
+
+1. **Summary** – Start with a concise, high-level overview of the recommendation or answer.
+2. **Explanation** – Follow with a detailed breakdown including reasoning, evidence, and trade-offs.
+3. **Closing** – End with a forward-looking action, checkpoint, or alignment question.
+
+Keep paragraphs tight, use numbered or bulleted lists when clarifying steps, and prefer verbs that imply ownership and momentum.

--- a/knowledge/permanent/resume.md
+++ b/knowledge/permanent/resume.md
@@ -1,0 +1,11 @@
+# Candidate Resume Snapshot
+
+- **Name**: Alex Dela Cruz
+- **Role**: Senior Full-Stack Engineer & Delivery Lead
+- **Experience**: 8+ years across fintech, healthtech, and SaaS platforms
+- **Core Skills**: TypeScript, React, Node.js, GraphQL, microservices, AWS, IaC (Terraform, CDK), CI/CD governance
+- **Leadership**: Leads hybrid squads, facilitates PI planning, and drives release management playbooks
+- **Highlights**:
+  - Scaled payments reconciliation pipeline to handle 5M transactions/day with automated variance detection.
+  - Championed AI-assisted QA suite that cut regression cycles by 40%.
+  - Implemented observability stack (OpenTelemetry + Grafana) for proactive incident response.

--- a/knowledge/project/current_project.md
+++ b/knowledge/project/current_project.md
@@ -1,0 +1,27 @@
+# Current Project: SecretInterview Offline Assistant
+
+## Objectives
+- Deliver an interview coaching assistant that operates fully offline using a local LLM.
+- Provide modular knowledge management with permanent and project-specific context.
+- Ensure workflows align with the AI Governor framework for predictable delivery.
+
+## Scope & Constraints
+- Runtime environment is Electron with React frontend.
+- Local LLM engines supported: Ollama, LM Studio, and vLLM.
+- Responses must follow summary → explanation → closing pattern.
+- Project updates occur by editing this file before each new engagement.
+
+## Stakeholders
+- Product Owner: Mia Santiago
+- Engineering Lead: Alex Dela Cruz
+- QA & Compliance: GovOps squad (automation + audits)
+
+## Technology Stack
+- Frontend: React + Tailwind within Electron shell
+- Backend Services: Local HTTP adapters for LLM engines
+- Tooling: Node.js, TypeScript, Webpack, Jest (unit tests), Playwright (UI tests)
+
+## Success Criteria
+- Interview flows run without external network dependency.
+- Knowledge layering seamlessly merges permanent docs with this project file.
+- AI responses cite workflow stages using the AI Governor reference when discussing governance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "form-data": "^4.0.0",
         "highlight.js": "^11.7.0",
         "node-fetch": "^2.7.0",
-        "openai": "^4.60.0",
         "pdf-parse": "^1.1.1",
         "prismjs": "^1.29.0",
         "react": "^18.3.1",
@@ -2273,6 +2272,7 @@
       "version": "6.9.15",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -2836,18 +2836,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2924,6 +2912,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
       "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -4324,6 +4313,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -5636,6 +5626,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6927,6 +6918,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
@@ -6939,6 +6931,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7373,15 +7366,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -8020,31 +8004,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -8347,6 +8312,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8592,6 +8558,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -8671,6 +8638,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -8683,6 +8651,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8695,6 +8664,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9213,6 +9183,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -11787,25 +11758,6 @@
         "semver": "^7.3.5"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-ensure": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
@@ -12031,6 +11983,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12193,49 +12146,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openai": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.60.0.tgz",
-      "integrity": "sha512-U/wNmrUPdfsvU1GrKRP5mY5YHR3ev6vtdfNID6Sauz+oquWD8r+cXPL1xiUlYniosPKajy33muVHhGS/9/t6KA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "@types/qs": "^6.9.15",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "qs": "^6.10.3"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -13264,6 +13174,7 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -14511,6 +14422,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -14634,6 +14546,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -16563,15 +16476,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "form-data": "^4.0.0",
     "highlight.js": "^11.7.0",
     "node-fetch": "^2.7.0",
-    "openai": "^4.60.0",
     "pdf-parse": "^1.1.1",
     "prismjs": "^1.29.0",
     "react": "^18.3.1",

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -5,7 +5,7 @@ import path from 'path';
 contextBridge.exposeInMainWorld('electronAPI', {
   getConfig: () => ipcRenderer.invoke('get-config'),
   setConfig: (config: any) => ipcRenderer.invoke('set-config', config),
-  testAPIConfig: (config: any) => ipcRenderer.invoke('test-api-config', config),
+  testLocalLLMConfig: (config: any) => ipcRenderer.invoke('test-local-llm', config),
   parsePDF: (buffer: ArrayBuffer) => ipcRenderer.invoke('parsePDF', buffer),
   processImage: (path: string) => ipcRenderer.invoke('process-image', path),
   highlightCode: (code: string, language: string) => ipcRenderer.invoke('highlight-code', code, language),
@@ -18,7 +18,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     removeListener: (channel: string, listener: (event: any, ...args: any[]) => void) => ipcRenderer.removeListener(channel, listener),
   },
-  callOpenAI: (params: any) => ipcRenderer.invoke('callOpenAI', params),
+  callLocalLLM: (params: any) => ipcRenderer.invoke('call-local-llm', params),
   loadAudioProcessor: (): Promise<string> => ipcRenderer.invoke('load-audio-processor'),
   getSystemAudioStream: () => ipcRenderer.invoke('get-system-audio-stream'),
   transcribeAudioFile: (filePath: string, config: any) => ipcRenderer.invoke('transcribe-audio-file', filePath, config),
@@ -30,4 +30,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startLocalAsr: (options: any) => ipcRenderer.invoke('start-local-asr', options),
   stopLocalAsr: () => ipcRenderer.invoke('stop-local-asr'),
   sendAudioToLocalAsr: (audioBuffer: ArrayBuffer) => ipcRenderer.send('send-audio-to-local-asr', audioBuffer),
+  loadKnowledgeContext: () => ipcRenderer.invoke('load-knowledge-context'),
+  saveProjectKnowledge: (payload: { content: string; fileName?: string }) => ipcRenderer.invoke('save-project-knowledge', payload),
+  setActiveProject: (fileName: string) => ipcRenderer.invoke('set-active-project', fileName),
 });

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -3,7 +3,7 @@ export interface ElectronAPI {
   transcribeAudioFile(tempFilePath: any, arg1: { primaryLanguage: string; secondaryLanguage: string; api_base: any; openai_key: any; }): TranscriptionResult | PromiseLike<TranscriptionResult>;
   getConfig: () => Promise<any>;
   setConfig: (config: any) => Promise<void>;
-  testAPIConfig: (config: any) => Promise<{ success: boolean, error?: string }>;
+  testLocalLLMConfig: (config: any) => Promise<{ success: boolean, error?: string }>;
   startRecording: () => Promise<Array<{id: string, name: string, thumbnail: string}>>;
   parsePDF: (pdfBuffer: ArrayBuffer) => Promise<{ text: string, error?: string }>;
   processImage: (imagePath: string) => Promise<string>;
@@ -16,7 +16,7 @@ export interface ElectronAPI {
     on(channel: string, listener: (event: any, ...args: any[]) => void): () => void;
     removeListener(channel: string, listener: (...args: any[]) => void): void;
   };
-  callOpenAI: (params: {
+  callLocalLLM: (params: {
     config: any;
     messages: any[];
     signal?: AbortSignal;
@@ -28,6 +28,14 @@ export interface ElectronAPI {
   startLocalAsr: (options: any) => Promise<{ success: boolean; error?: string }>;
   stopLocalAsr: () => Promise<{ success: boolean }>;
   sendAudioToLocalAsr: (audioBuffer: ArrayBuffer) => void;
+  loadKnowledgeContext: () => Promise<{
+    permanent: Array<{ fileName: string; title: string; content: string; path: string }>;
+    project: { fileName: string; title: string; content: string; path: string } | null;
+    availableProjects: string[];
+    error?: string;
+  }>;
+  saveProjectKnowledge: (payload: { content: string; fileName?: string }) => Promise<{ success: boolean; error?: string }>;
+  setActiveProject: (fileName: string) => Promise<{ success: boolean; error?: string }>;
 }
 
 declare global {

--- a/src/services/conversationMemory.ts
+++ b/src/services/conversationMemory.ts
@@ -13,7 +13,7 @@ export interface SummaryGenerationResult {
 }
 
 /**
- * Generates a conversation summary using OpenAI
+ * Generates a conversation summary using the configured local LLM
  */
 export async function generateConversationSummary(
   request: SummaryGenerationRequest
@@ -42,7 +42,7 @@ Please respond in the following JSON format:
   "tags": ["tag1", "tag2", "tag3"]
 }`;
 
-    const response = await window.electronAPI.callOpenAI({
+    const response = await window.electronAPI.callLocalLLM({
       config: config,
       messages: [
         { role: "system", content: "You are a helpful assistant that creates structured summaries for conversation memory." },
@@ -77,15 +77,13 @@ Please respond in the following JSON format:
 }
 
 /**
- * Generates embeddings for text using OpenAI
+ * Generates embeddings for text (placeholder implementation)
  */
 export async function generateEmbedding(text: string): Promise<number[]> {
   try {
     const config = await window.electronAPI.getConfig();
     
-    // For now, we'll use a simple hash-based approach since OpenAI embeddings API
-    // might not be available in all configurations
-    // In a production system, you'd call the embeddings API here
+    // Simple hash-based approach while offline embeddings are unavailable.
     
     // Simple hash-based "embedding" for demonstration
     const hash = text.split('').reduce((a, b) => {

--- a/src/services/profileExtractor.ts
+++ b/src/services/profileExtractor.ts
@@ -7,13 +7,13 @@ export interface ProfileExtractionResult {
 }
 
 /**
- * Extracts structured profile information from parsed file text using OpenAI function calling
+ * Extracts structured profile information from parsed file text using the configured local LLM
  * @param fileText - The parsed text content from uploaded files
  * @returns Promise<ProfileExtractionResult> - Structured profile data or error
  */
 export async function extractProfileFromText(fileText: string): Promise<ProfileExtractionResult> {
   try {
-    // Get the OpenAI configuration
+    // Get the current configuration
     const config = await window.electronAPI.getConfig();
     
     // Create the prompt for profile extraction
@@ -37,14 +37,14 @@ export async function extractProfileFromText(fileText: string): Promise<ProfileE
 
     const userPrompt = `Please extract profile information from the following text:\n\n${fileText}`;
 
-    // Prepare messages for OpenAI API call
+    // Prepare messages for the local LLM call
     const messages = [
       { role: "system", content: systemPrompt },
       { role: "user", content: userPrompt }
     ];
 
-    // Call OpenAI
-    const response = await window.electronAPI.callOpenAI({
+    // Call local LLM
+    const response = await window.electronAPI.callLocalLLM({
       config: config,
       messages: messages
     });
@@ -52,11 +52,11 @@ export async function extractProfileFromText(fileText: string): Promise<ProfileE
     if ('error' in response) {
       return {
         success: false,
-        error: `OpenAI API error: ${response.error}`
+        error: `Local LLM error: ${response.error}`
       };
     }
 
-    // Parse the JSON response from OpenAI
+    // Parse the JSON response from the LLM
     try {
       const extractedData = JSON.parse(response.content);
       

--- a/src/utils/promptBuilder.ts
+++ b/src/utils/promptBuilder.ts
@@ -1,4 +1,4 @@
-import { KnowledgeCategory, KnowledgeEntry, ProfileSummary } from '../contexts/KnowledgeBaseContext';
+import { KnowledgeCategory, KnowledgeEntry, KnowledgeDocumentsState, ProfileSummary } from '../contexts/KnowledgeBaseContext';
 
 export interface InterviewScenario {
   id: string;
@@ -91,7 +91,8 @@ export const INTERVIEW_SCENARIOS: InterviewScenario[] = [
 export function buildInterviewPrompt(
   profileSummary: ProfileSummary | null,
   scenario: InterviewScenario,
-  knowledgeBase?: Record<KnowledgeCategory, KnowledgeEntry[]>
+  knowledgeBase?: Record<KnowledgeCategory, KnowledgeEntry[]>,
+  knowledgeDocuments?: KnowledgeDocumentsState
 ): string {
   let prompt = `${scenario.systemPrompt}\n\n`;
 
@@ -136,6 +137,21 @@ export function buildInterviewPrompt(
   prompt += `- Suggest follow-up questions\n`;
   prompt += `- Offer insights on the candidate's responses\n`;
   prompt += `- Maintain consistency with the interview scenario focus\n`;
+
+  if (knowledgeDocuments) {
+    if (knowledgeDocuments.permanent.length > 0) {
+      prompt += `\n## Permanent Knowledge Base\n`;
+      knowledgeDocuments.permanent.forEach(document => {
+        prompt += `\n### ${document.title}\n`;
+        prompt += `${document.content.trim()}\n`;
+      });
+    }
+
+    if (knowledgeDocuments.project) {
+      prompt += `\n## Project Knowledge: ${knowledgeDocuments.project.title}\n`;
+      prompt += `${knowledgeDocuments.project.content.trim()}\n`;
+    }
+  }
 
   if (knowledgeBase) {
     const appendSection = (title: string, entries?: KnowledgeEntry[], limit: number = 5) => {


### PR DESCRIPTION
## Summary
- replace remote OpenAI usage with a local LLM adapter, configuration UI, and diagnostic test hook
- add permanent and project knowledge layers with Electron APIs plus on-app editing of the active project brief
- update interview, knowledge, and summarization flows to assemble prompts from the layered knowledge and call the local engine

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68e7aa97f2a0832ea8e6984a03b113c2