### PR TITLE
feat: switch to local llm and modular knowledge layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Interview Assistant 是一款基于 Electron 的应用，可以捕获系统音�
 ## 为什么是Interview Assistant
 
 1. **实时语音转文字**: 利用 Deepgram API 实现实时语音识别。
-2. **智能 GPT 回答**: 集成 OpenAI 的 GPT 模型，为面试问题提供即时、智能的回答建议。(支持带转发地址的第三方API)
+2. **本地 LLM 回答**: 集成本地部署的 LLM 引擎（Ollama/LM Studio/vLLM），离线生成面试回答与建议，无需任何外部 API。
 3. **内容管理**: 用户可以上传自己的文件，包括文本、图片和 PDF 文件，和你自己定制的提示词，可以极大的定制你想要GPT回应的风格，这些资料将用于个性化 GPT 的回答。
 4. **统一上下文**: 在实时回答页面中，对话基于知识页面的配置，都在同一个上下文中进行，确保回答的连贯性和相关性。
 5. **跨平台支持**: 作为 Electron 应用，可以在 Windows、macOS系统上运行。
@@ -45,15 +45,16 @@ Interview Assistant 相比其他面试辅助工具有以下优势：
 
 1. 从 Release 页面下载适合您操作系统的安装包。
 2. 运行 Interview Assistant。
-3. 在设置页面配置您的 OpenAI API 密钥和 Deepgram API 密钥。
+3. 在设置页面配置本地 LLM 服务（模型、URL 等）以及可选的 Deepgram 备用密钥。
 4. 开始使用实时面试辅助功能或管理您的知识库。
 
 ## 配置说明
 
 要使用 Interview Assistant，您需要：
 
-1. OpenAI API 密钥: 可以从 https://platform.openai.com 获取，或者可以购买第三方带有转发地址的API也同样支持，记得选择转发的复选框，配置完成后可以点击测试按钮进行测试。
-2. Deepgram API 密钥: 请访问 https://deepgram.com 注册并获取，新用户有200美元的免费额度，首页教程简单。
+1. 本地 LLM 服务: 确保 Ollama、LM Studio 或兼容的 HTTP 接口正在运行，并在设置中配置 Base URL、模型名称等参数。
+2. Deepgram API 密钥（可选）: 作为本地语音识别的备用方案，可访问 https://deepgram.com 注册获取。
+3. 知识库分层: `knowledge/permanent` 下的 Markdown 提供固定人格与流程，`knowledge/projects/current_project.md` 保存当前项目上下文，可按项目替换。
 
 ![image-20240919163506505](https://cdn.jsdelivr.net/gh/filifili233/blogimg@master/uPic/image-20240919163506505.png)
 
@@ -80,7 +81,7 @@ Interview Assistant is an Electron-based application that captures system audio 
 ## Why Interview Assistant
 
 1. **Real-time Speech-to-Text**: Runs a local GPU-accelerated Whisper/ASR engine for sub-300&nbsp;ms streaming transcription and automatically falls back to Deepgram only when the local engine is unavailable.
-2. **Intelligent GPT Responses**: Integrates OpenAI's GPT model to provide instant, intelligent answer suggestions for interview questions. (Supports third-party APIs with forwarding addresses)
+2. **Local LLM Responses**: Integrates an offline LLM engine (Ollama/LM Studio/vLLM compatible) to provide instant, intelligent interview guidance without any external APIs.
 3. **Content Management**: Users can upload their own files, including text, images, and PDF files, along with customized prompts, greatly customizing the style of GPT responses. These materials will be used to personalize GPT's answers.
 4. **Unified Context**: In the real-time response page, conversations are based on the knowledge page configuration, all within the same context, ensuring coherence and relevance of answers.
 5. **Cross-platform Support**: As an Electron application, it can run on Windows and macOS systems.
@@ -115,16 +116,17 @@ This comparison table clearly shows the advantages of Interview Assistant compar
 
 1. Download the installation package suitable for your operating system from the Release page.
 2. Run Interview Assistant.
-3. Configure your OpenAI API key, optional local ASR binary, and (fallback) Deepgram API key on the settings page.
+3. Configure your local LLM endpoint (model, base URL, options) and optional Deepgram fallback key on the settings page.
 4. Start using the real-time interview assistance feature or manage your knowledge base.
 
 ## Configuration Instructions
 
 To use Interview Assistant, you need:
 
-1. OpenAI API key: Can be obtained from https://platform.openai.com, or you can purchase a third-party API with a forwarding address which is also supported. Remember to select the forwarding checkbox, and you can click the test button to test after configuration.
+1. Local LLM endpoint: Run Ollama, LM Studio, vLLM, or any OpenAI-compatible local server and provide the base URL, model name, and sampling settings.
 2. Local ASR engine (recommended): Provide the path to your GPU-enabled Whisper/ASR binary and model files. The application streams 16&nbsp;kHz PCM chunks (~64&nbsp;ms) to keep end-to-end latency below 300&nbsp;ms using GPU parallel inference.
 3. Deepgram API key (optional fallback): Please visit https://deepgram.com to register and obtain. New users get $200 free credit, and the homepage tutorial is simple.
+4. Knowledge layers: Permanent Markdown files live in `knowledge/permanent`, while the active project context lives in `knowledge/projects/current_project.md`. Swap this file per engagement.
 
 ![image-20240919163506505](https://cdn.jsdelivr.net/gh/filifili233/blogimg@master/uPic/image-20240919163506505.png)
 

--- a/knowledge/permanent/ai_governor_framework.md
+++ b/knowledge/permanent/ai_governor_framework.md
@@ -1,0 +1,17 @@
+# AI Governor Framework
+
+## Governance Layers
+1. **Discovery** – Capture goals, stakeholders, constraints, and initial risks. Validate problem framing before suggesting action.
+2. **Planning** – Translate goals into measurable milestones, assign owners, and map dependencies. Ensure compliance and security checks are in scope.
+3. **Delivery** – Drive execution with sprint-level clarity, surface blockers early, and align with CI/CD quality gates (tests, code review, compliance scans).
+4. **Review** – Measure outcomes, document learnings, and update the knowledge base. Close out risks or convert them into new backlog items.
+
+## Automation & Tooling
+- Favor automation that reduces cycle time but maintain human approvals at critical control points.
+- Enforce CI/CD quality gates: automated tests, static analysis, security scanning, and deployment sign-off.
+- Track metrics: lead time, defect rate, blocker resolution time, and stakeholder satisfaction.
+
+## Compliance
+- Document decisions with traceability to requirements and approvals.
+- Ensure data handling follows project-specific governance rules.
+- Escalate non-compliance immediately with mitigation options.

--- a/knowledge/permanent/behavior_rules.md
+++ b/knowledge/permanent/behavior_rules.md
@@ -1,0 +1,8 @@
+# Interview Assistant Behavior Rules
+
+- Always operate as the Interview Assistant AI Governor.
+- Follow the governance checkpoints defined in the AI Governor Framework before issuing guidance.
+- Keep track of conversation objectives, risks, and next actions across the interview lifecycle.
+- Never fabricate project facts—rely on the permanent and project knowledge sources only.
+- Encourage structured thinking and reflective answers from the candidate.
+- Provide actionable follow ups that map to the governance stages (Discovery, Planning, Delivery, Review).

--- a/knowledge/permanent/language_tone_guide.md
+++ b/knowledge/permanent/language_tone_guide.md
@@ -1,0 +1,7 @@
+# Language and Tone Guide
+
+- Blend Filipino and English naturally; keep sentences short and conversational.
+- Use everyday expressions such as “No problem,” “Let’s align,” and “Already working on it.”
+- Maintain a steady rhythm—no overly formal or academic phrasing.
+- Prefer active voice and direct statements (e.g., “We deploy tonight” instead of “Deployment will be executed tonight”).
+- When flagging risks, stay calm and pragmatic. Offer mitigation steps immediately.

--- a/knowledge/permanent/response_style.md
+++ b/knowledge/permanent/response_style.md
@@ -1,0 +1,11 @@
+# Response Style Blueprint
+
+1. **Summary (2 sentences max)**
+   - Capture the main recommendation or answer immediately.
+2. **Explanation (bullet points)**
+   - Provide 2–4 concise bullets linking actions to governance layers and project context.
+   - Highlight risks, dependencies, or metrics tied to the AI Governor Framework.
+3. **Closing (1 sentence)**
+   - Offer a clear next step or check-in question that advances the interview agenda.
+
+Always keep language human, direct, and confident. Avoid filler phrases and keep responses under 180 words unless explicitly requested.

--- a/knowledge/permanent/resume.md
+++ b/knowledge/permanent/resume.md
@@ -1,0 +1,9 @@
+# Resume Snapshot
+
+**Name:** Alex Dela Cruz
+**Role:** Senior AI Solutions Architect & Interview Coach
+
+- 12+ years building AI-driven platforms for enterprise clients across finance, health, and logistics.
+- Led interview readiness programs for 200+ professionals transitioning into AI/product roles.
+- Expert in LLM fine-tuning, evaluation pipelines, and human-in-the-loop governance.
+- Certified in Agile Delivery, ISO 27001 compliance, and cloud security assessments.

--- a/knowledge/projects/current_project.md
+++ b/knowledge/projects/current_project.md
@@ -1,0 +1,21 @@
+# Project: SecretInterview Modernization
+
+## Goals
+- Deliver a fully offline interview simulation tool for engineering candidates.
+- Replace cloud LLM calls with a local inference stack to ensure privacy and reliability.
+- Standardize interview coaching outputs around the AI Governor Framework.
+
+## Requirements
+- Integrate with Ollama-compatible models (default: `llama3.1:8b`) served locally.
+- Support modular knowledge loading so each client engagement can swap project files without code changes.
+- Maintain electron-based UI/UX with existing prompt assembly features.
+
+## Stack & Tooling
+- Electron + React front-end
+- Local ASR via Whisper or Deepgram fallback
+- Local LLM served via HTTP on `http://localhost:11434`
+
+## Risks & Considerations
+- Ensure prompt context stays within token limits when combining permanent + project knowledge.
+- Validate latency of local model before live interviews; cache knowledge context to reduce overhead.
+- Provide clear guidance when the local model is unreachable or misconfigured.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "form-data": "^4.0.0",
         "highlight.js": "^11.7.0",
         "node-fetch": "^2.7.0",
-        "openai": "^4.60.0",
         "pdf-parse": "^1.1.1",
         "prismjs": "^1.29.0",
         "react": "^18.3.1",
@@ -2273,6 +2272,7 @@
       "version": "6.9.15",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -2836,18 +2836,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2924,6 +2912,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
       "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -4324,6 +4313,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -5636,6 +5626,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6927,6 +6918,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
@@ -6939,6 +6931,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7373,15 +7366,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -8020,31 +8004,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -8347,6 +8312,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8592,6 +8558,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -8671,6 +8638,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -8683,6 +8651,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8695,6 +8664,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9213,6 +9183,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -11787,25 +11758,6 @@
         "semver": "^7.3.5"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-ensure": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
@@ -12031,6 +11983,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12193,49 +12146,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openai": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.60.0.tgz",
-      "integrity": "sha512-U/wNmrUPdfsvU1GrKRP5mY5YHR3ev6vtdfNID6Sauz+oquWD8r+cXPL1xiUlYniosPKajy33muVHhGS/9/t6KA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "@types/qs": "^6.9.15",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "qs": "^6.10.3"
-      },
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.50.tgz",
-      "integrity": "sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -13264,6 +13174,7 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
       "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -14511,6 +14422,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -14634,6 +14546,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -16563,15 +16476,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "form-data": "^4.0.0",
     "highlight.js": "^11.7.0",
     "node-fetch": "^2.7.0",
-    "openai": "^4.60.0",
     "pdf-parse": "^1.1.1",
     "prismjs": "^1.29.0",
     "react": "^18.3.1",

--- a/src/local-llm/LocalLlmClient.ts
+++ b/src/local-llm/LocalLlmClient.ts
@@ -1,0 +1,144 @@
+import axios, { AxiosInstance } from 'axios';
+
+export type LlmRole = 'system' | 'user' | 'assistant';
+
+export interface LlmMessage {
+  role: LlmRole;
+  content: string;
+}
+
+export interface LocalLlmConfig {
+  baseUrl: string;
+  model: string;
+  provider?: 'ollama' | 'lmstudio' | 'vllm' | 'generic';
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+  requestPath?: string;
+}
+
+export interface InvokeLlmOptions {
+  config: LocalLlmConfig;
+  messages: LlmMessage[];
+  signal?: AbortSignal;
+}
+
+export interface LocalLlmResult {
+  content: string;
+}
+
+function sanitizeBaseUrl(url: string): string {
+  if (!url) {
+    return 'http://localhost:11434';
+  }
+  const trimmed = url.replace(/\/$/, '');
+  return trimmed;
+}
+
+function createAxiosInstance(config: LocalLlmConfig, signal?: AbortSignal): AxiosInstance {
+  return axios.create({
+    baseURL: sanitizeBaseUrl(config.baseUrl),
+    signal,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+async function invokeOllama(config: LocalLlmConfig, messages: LlmMessage[], signal?: AbortSignal): Promise<string> {
+  const client = createAxiosInstance(config, signal);
+  const response = await client.post('/api/chat', {
+    model: config.model,
+    messages,
+    stream: false,
+    options: {
+      temperature: config.temperature ?? 0.7,
+      top_p: config.topP ?? 0.9,
+      num_predict: config.maxTokens,
+    },
+  });
+
+  if (response.data?.message?.content) {
+    return response.data.message.content as string;
+  }
+
+  if (Array.isArray(response.data?.messages)) {
+    const last = response.data.messages[response.data.messages.length - 1];
+    if (last?.content) {
+      return last.content as string;
+    }
+  }
+
+  throw new Error('Unexpected response from Ollama local LLM');
+}
+
+async function invokeLmStudio(config: LocalLlmConfig, messages: LlmMessage[], signal?: AbortSignal): Promise<string> {
+  const client = createAxiosInstance(config, signal);
+  const response = await client.post('/v1/chat/completions', {
+    model: config.model,
+    messages,
+    temperature: config.temperature ?? 0.7,
+    top_p: config.topP ?? 0.9,
+    max_tokens: config.maxTokens,
+    stream: false,
+  });
+
+  const choice = response.data?.choices?.[0]?.message;
+  if (choice?.content) {
+    return choice.content as string;
+  }
+  throw new Error('Unexpected response from LM Studio local LLM');
+}
+
+async function invokeGeneric(config: LocalLlmConfig, messages: LlmMessage[], signal?: AbortSignal): Promise<string> {
+  const client = createAxiosInstance(config, signal);
+  const path = config.requestPath || '/v1/chat/completions';
+  const response = await client.post(path, {
+    model: config.model,
+    messages,
+    temperature: config.temperature ?? 0.7,
+    top_p: config.topP ?? 0.9,
+    max_tokens: config.maxTokens,
+    stream: false,
+  });
+
+  const choice = response.data?.choices?.[0]?.message;
+  if (choice?.content) {
+    return choice.content as string;
+  }
+  throw new Error('Unexpected response from local LLM');
+}
+
+export async function invokeLocalLlm({ config, messages, signal }: InvokeLlmOptions): Promise<LocalLlmResult> {
+  const provider = config.provider ?? 'ollama';
+  let content: string;
+
+  switch (provider) {
+    case 'ollama':
+      content = await invokeOllama(config, messages, signal);
+      break;
+    case 'lmstudio':
+    case 'vllm':
+      content = await invokeLmStudio(config, messages, signal);
+      break;
+    default:
+      content = await invokeGeneric(config, messages, signal);
+      break;
+  }
+
+  return { content: content.trim() };
+}
+
+export async function testLocalLlm(config: LocalLlmConfig): Promise<void> {
+  const result = await invokeLocalLlm({
+    config,
+    messages: [
+      { role: 'system', content: 'You are a diagnostic agent verifying connectivity.' },
+      { role: 'user', content: 'Reply with the single word "online" if you received this message.' },
+    ],
+  });
+
+  if (!/online/i.test(result.content)) {
+    throw new Error('Local LLM responded unexpectedly. Received: ' + result.content.slice(0, 120));
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,11 +1,9 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import fs from 'fs';
-import path from 'path';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getConfig: () => ipcRenderer.invoke('get-config'),
   setConfig: (config: any) => ipcRenderer.invoke('set-config', config),
-  testAPIConfig: (config: any) => ipcRenderer.invoke('test-api-config', config),
+  testLocalLlmConfig: (config: any) => ipcRenderer.invoke('test-local-llm', config),
   parsePDF: (buffer: ArrayBuffer) => ipcRenderer.invoke('parsePDF', buffer),
   processImage: (path: string) => ipcRenderer.invoke('process-image', path),
   highlightCode: (code: string, language: string) => ipcRenderer.invoke('highlight-code', code, language),
@@ -18,7 +16,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     removeListener: (channel: string, listener: (event: any, ...args: any[]) => void) => ipcRenderer.removeListener(channel, listener),
   },
-  callOpenAI: (params: any) => ipcRenderer.invoke('callOpenAI', params),
+  invokeLocalLlm: (params: any) => ipcRenderer.invoke('invoke-local-llm', params),
   loadAudioProcessor: (): Promise<string> => ipcRenderer.invoke('load-audio-processor'),
   getSystemAudioStream: () => ipcRenderer.invoke('get-system-audio-stream'),
   transcribeAudioFile: (filePath: string, config: any) => ipcRenderer.invoke('transcribe-audio-file', filePath, config),
@@ -30,4 +28,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startLocalAsr: (options: any) => ipcRenderer.invoke('start-local-asr', options),
   stopLocalAsr: () => ipcRenderer.invoke('stop-local-asr'),
   sendAudioToLocalAsr: (audioBuffer: ArrayBuffer) => ipcRenderer.send('send-audio-to-local-asr', audioBuffer),
+  loadKnowledgeContext: () => ipcRenderer.invoke('load-knowledge-context'),
 });

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -3,7 +3,7 @@ export interface ElectronAPI {
   transcribeAudioFile(tempFilePath: any, arg1: { primaryLanguage: string; secondaryLanguage: string; api_base: any; openai_key: any; }): TranscriptionResult | PromiseLike<TranscriptionResult>;
   getConfig: () => Promise<any>;
   setConfig: (config: any) => Promise<void>;
-  testAPIConfig: (config: any) => Promise<{ success: boolean, error?: string }>;
+  testLocalLlmConfig: (config: any) => Promise<{ success: boolean, error?: string }>;
   startRecording: () => Promise<Array<{id: string, name: string, thumbnail: string}>>;
   parsePDF: (pdfBuffer: ArrayBuffer) => Promise<{ text: string, error?: string }>;
   processImage: (imagePath: string) => Promise<string>;
@@ -16,10 +16,9 @@ export interface ElectronAPI {
     on(channel: string, listener: (event: any, ...args: any[]) => void): () => void;
     removeListener(channel: string, listener: (...args: any[]) => void): void;
   };
-  callOpenAI: (params: {
+  invokeLocalLlm: (params: {
     config: any;
     messages: any[];
-    signal?: AbortSignal;
   }) => Promise<{ content: string } | { error: string }>;
   transcribeAudio: (audioBuffer: ArrayBuffer, config: any) => Promise<TranscriptionResult>;
   readPromptTemplate: (templateName: string) => Promise<{ content: string } | { error: string }>;
@@ -28,6 +27,11 @@ export interface ElectronAPI {
   startLocalAsr: (options: any) => Promise<{ success: boolean; error?: string }>;
   stopLocalAsr: () => Promise<{ success: boolean }>;
   sendAudioToLocalAsr: (audioBuffer: ArrayBuffer) => void;
+  loadKnowledgeContext: () => Promise<{
+    permanent: Array<{ filename: string; title: string; content: string }>;
+    project: { filename: string; title: string; content: string } | null;
+    combined: string;
+  }>;
 }
 
 declare global {

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -23,6 +23,10 @@ export const mainConfig: Configuration = {
           from: path.resolve(__dirname, 'prompts'),
           to: path.resolve(__dirname, '.webpack/main/prompts'),
         },
+        {
+          from: path.resolve(__dirname, 'knowledge'),
+          to: path.resolve(__dirname, '.webpack/main/knowledge'),
+        },
       ],
     }),
   ],


### PR DESCRIPTION
## Summary
- replace OpenAI usage with a local LLM client and IPC handlers, including packaging the knowledge directory
- add permanent and project knowledge markdown sources plus context management in the renderer
- refresh interview, knowledge base, and settings flows to consume the local LLM, expose knowledge reload controls, and document the offline workflow

## Testing
- `npm run package` *(fails: interrupted after long build spinner to avoid hanging)*

------
https://chatgpt.com/codex/tasks/task_e_68e7aa97f2a0832ea8e6984a03b113c2